### PR TITLE
Send `spoor-test: true` as a string

### DIFF
--- a/app/services/spoor.server.services.js
+++ b/app/services/spoor.server.services.js
@@ -21,7 +21,7 @@ exports.send = (event) => {
             headers: {
                 'Accept': 'application/json',
                 'Content-Type': 'application/json',
-                'spoor-test': true,
+                'spoor-test': 'true',
                 'Content-Length': length,
                 "spoor-region": Math.round(Math.random()) ? 'EU' : 'US', //Randomly assign a different region
                 'User-Agent': 'ft-email-service/v1.1'


### PR DESCRIPTION
As node-fetch doesn't send boolean values in the request